### PR TITLE
Simple history implementation

### DIFF
--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -25,6 +25,16 @@ impl LineBuffer {
         &self.buffer
     }
 
+    pub fn set_buffer(&mut self, buffer: String) {
+        self.buffer = buffer;
+    }
+
+    pub fn move_to_end(&mut self) -> usize {
+        self.insertion_point = self.buffer.len();
+
+        self.insertion_point
+    }
+
     fn get_grapheme_indices(&self) -> Vec<(usize, &str)> {
         UnicodeSegmentation::grapheme_indices(self.buffer.as_str(), true).collect()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,13 @@ use crossterm::{
     terminal, ExecutableCommand, QueueableCommand, Result,
 };
 
+use std::collections::VecDeque;
 use std::io::Stdout;
 
 mod line_buffer;
 use line_buffer::LineBuffer;
+
+const HISTORY_SIZE: usize = 100;
 
 fn print_message(stdout: &mut Stdout, msg: &str) -> Result<()> {
     stdout
@@ -31,6 +34,8 @@ fn main() -> Result<()> {
     terminal::enable_raw_mode()?;
 
     let mut buffer = LineBuffer::new();
+    let mut history = VecDeque::with_capacity(HISTORY_SIZE);
+    let mut history_cursor = 0usize;
 
     'repl: loop {
         // print our prompt
@@ -107,6 +112,15 @@ fn main() -> Result<()> {
                             if buffer.get_buffer() == "exit" {
                                 break 'repl;
                             } else {
+                                if history.len() + 1 == HISTORY_SIZE {
+                                    // History is "full", so we delete the oldest entry first,
+                                    // before adding a new one.
+                                    history.pop_back();
+                                }
+                                history.push_front(String::from(buffer.get_buffer()));
+                                // reset the history cursor - we want to start at the bottom of the
+                                // history again.
+                                history_cursor = 0;
                                 print_message(
                                     &mut stdout,
                                     &format!("Our buffer: {}", buffer.get_buffer()),
@@ -114,6 +128,34 @@ fn main() -> Result<()> {
                                 buffer.clear();
                                 buffer.set_insertion_point(0);
                                 break 'input;
+                            }
+                        }
+                        KeyCode::Up => {
+                            // Up means: navigate through the history.
+                            if let Some(history_entry) = history.get(history_cursor) {
+                                let previous_buffer_len = buffer.get_buffer_len();
+                                buffer.set_buffer(history_entry.clone());
+                                let new_buffer_len = buffer.get_buffer_len();
+                                let new_insertion_point = buffer.move_to_end();
+                                history_cursor += 1;
+
+                                // After changing the buffer, we also need to repaint the whole
+                                // line.
+                                // TODO: Centralize painting of the line?!
+                                stdout
+                                    .queue(MoveToColumn(prompt_offset))?
+                                    .queue(Print(buffer.get_buffer()))?;
+
+                                // Print over the rest of the line with spaces if the typed stuff
+                                // was longer than the history entry length
+                                for _ in 0..(previous_buffer_len - new_buffer_len) {
+                                    stdout.queue(Print(" "))?;
+                                }
+                                stdout
+                                    .queue(MoveToColumn(
+                                        new_insertion_point as u16 + prompt_offset,
+                                    ))?
+                                    .flush()?;
                             }
                         }
                         KeyCode::Left => {


### PR DESCRIPTION
This PR provides a very simple history implementation by saving buffers into a `VecDeque` when they are "confirmed" by pressing enter. The history currently allows 100 entries, which can be changed by changing the `HISTORY_SIZE` constant in `main.rs`.  
Navigation through the history works by pressing Up/Down arrow keys and feels pretty much the same as in bash or zsh. The implementation comes with a little bit of code duplication that I left there intentionally since I didn't want to take the fun of doing cool refactorings from the stream ;) 

If you want, I could of course improve that implementation by moving repainting of the current line buffer into a separate method or something like this. Just let me know!

The current implementation doesn't support persisting the history on disk for re-using it between launches and also does no fancy matching of the characters that are currently in the buffer to only match on history entries that start with the same characters, like zsh does it. If you'd like me to add something like this, also let me know, but that might be better for a separate PR. Also, I wasn't too sure if a history implementation belongs to the line editor or more to the application that uses the line editor. Most likely, the history should be more like an API that the outside program uses to provide the history to the line editor?! 