### PR TITLE
add diagnostic routine with cmd line arg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,92 +91,176 @@ fn main() -> Result<()> {
     if args.len() > 1 && args[1] == "-k" {
         print_message(&mut stdout, "Ready to print events:")?;
         print_events(&mut stdout)?;
-    } else {
-        let mut buffer = LineBuffer::new();
-        let mut history = VecDeque::with_capacity(HISTORY_SIZE);
-        let mut history_cursor = -1i64;
-        let mut has_history = false;
-        let mut cut_buffer = String::new();
+        terminal::disable_raw_mode()?;
+        println!();
+        return Ok(());
+    };
 
-        'repl: loop {
-            // print our prompt
-            stdout
-                .execute(SetForegroundColor(Color::Blue))?
-                .execute(Print("> "))?
-                .execute(ResetColor)?;
+    let mut buffer = LineBuffer::new();
+    let mut history = VecDeque::with_capacity(HISTORY_SIZE);
+    let mut history_cursor = -1i64;
+    let mut has_history = false;
+    let mut cut_buffer = String::new();
 
-            // set where the input begins
-            let (mut prompt_offset, _) = position()?;
-            prompt_offset += 1;
+    'repl: loop {
+        // print our prompt
+        stdout
+            .execute(SetForegroundColor(Color::Blue))?
+            .execute(Print("> "))?
+            .execute(ResetColor)?;
 
-            'input: loop {
-                match read()? {
-                    Event::Key(KeyEvent {
-                        code,
-                        modifiers: KeyModifiers::CONTROL,
-                    }) => match code {
-                        KeyCode::Char('d') => {
-                            if buffer.get_buffer().is_empty() {
-                                stdout.queue(MoveToNextLine(1))?.queue(Print("exit"))?;
-                                break 'repl;
-                            } else {
-                                let insertion_point = buffer.get_insertion_point();
-                                if insertion_point < buffer.get_buffer_len() && !buffer.is_empty() {
-                                    buffer.remove_char(insertion_point);
-                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                                }
-                            }
-                        }
-                        KeyCode::Char('a') => {
-                            buffer.set_insertion_point(0);
-                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                        }
-                        KeyCode::Char('e') => {
-                            let buffer_len = buffer.get_buffer_len();
-                            buffer.set_insertion_point(buffer_len);
-                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                        }
-                        KeyCode::Char('k') => {
-                            let cut_slice = &buffer.get_buffer()[buffer.get_insertion_point()..];
-                            if !cut_slice.is_empty() {
-                                cut_buffer.replace_range(.., cut_slice);
-                                buffer.clear_to_end();
+        // set where the input begins
+        let (mut prompt_offset, _) = position()?;
+        prompt_offset += 1;
+
+        'input: loop {
+            match read()? {
+                Event::Key(KeyEvent {
+                    code,
+                    modifiers: KeyModifiers::CONTROL,
+                }) => match code {
+                    KeyCode::Char('d') => {
+                        if buffer.get_buffer().is_empty() {
+                            stdout.queue(MoveToNextLine(1))?.queue(Print("exit"))?;
+                            break 'repl;
+                        } else {
+                            let insertion_point = buffer.get_insertion_point();
+                            if insertion_point < buffer.get_buffer_len() && !buffer.is_empty() {
+                                buffer.remove_char(insertion_point);
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             }
                         }
-                        KeyCode::Char('u') => {
-                            if buffer.get_insertion_point() > 0 {
-                                cut_buffer.replace_range(
-                                    ..,
-                                    &buffer.get_buffer()[..buffer.get_insertion_point()],
-                                );
-                                buffer.clear_to_insertion_point();
-                                buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                            }
+                    }
+                    KeyCode::Char('a') => {
+                        buffer.set_insertion_point(0);
+                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                    }
+                    KeyCode::Char('e') => {
+                        let buffer_len = buffer.get_buffer_len();
+                        buffer.set_insertion_point(buffer_len);
+                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                    }
+                    KeyCode::Char('k') => {
+                        let cut_slice = &buffer.get_buffer()[buffer.get_insertion_point()..];
+                        if !cut_slice.is_empty() {
+                            cut_buffer.replace_range(.., cut_slice);
+                            buffer.clear_to_end();
+                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                         }
-                        KeyCode::Char('y') => {
-                            buffer.insert_str(buffer.get_insertion_point(), &cut_buffer);
-                            buffer.set_insertion_point(
-                                buffer.get_insertion_point() + cut_buffer.len(),
+                    }
+                    KeyCode::Char('u') => {
+                        if buffer.get_insertion_point() > 0 {
+                            cut_buffer.replace_range(
+                                ..,
+                                &buffer.get_buffer()[..buffer.get_insertion_point()],
                             );
+                            buffer.clear_to_insertion_point();
                             buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                         }
-                        KeyCode::Char('b') => {
+                    }
+                    KeyCode::Char('y') => {
+                        buffer.insert_str(buffer.get_insertion_point(), &cut_buffer);
+                        buffer.set_insertion_point(buffer.get_insertion_point() + cut_buffer.len());
+                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                    }
+                    KeyCode::Char('b') => {
+                        buffer.dec_insertion_point();
+                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                    }
+                    KeyCode::Char('f') => {
+                        buffer.inc_insertion_point();
+                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                    }
+                    KeyCode::Char('c') => {
+                        buffer.clear();
+                        stdout.queue(Print('\n'))?.queue(MoveToColumn(1))?.flush()?;
+                        break 'input;
+                    }
+                    KeyCode::Char('h') => {
+                        let insertion_point = buffer.get_insertion_point();
+                        if insertion_point == buffer.get_buffer_len() && !buffer.is_empty() {
+                            buffer.pop();
+                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                        } else if insertion_point < buffer.get_buffer_len()
+                            && insertion_point > 0
+                            && !buffer.is_empty()
+                        {
                             buffer.dec_insertion_point();
+                            let insertion_point = buffer.get_insertion_point();
+                            buffer.remove_char(insertion_point);
                             buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                         }
-                        KeyCode::Char('f') => {
+                    }
+                    KeyCode::Char('w') => {
+                        let old_insertion_point = buffer.get_insertion_point();
+                        buffer.move_word_left();
+                        if buffer.get_insertion_point() < old_insertion_point {
+                            cut_buffer.replace_range(
+                                ..,
+                                &buffer.get_buffer()
+                                    [buffer.get_insertion_point()..old_insertion_point],
+                            );
+                            buffer.clear_range(buffer.get_insertion_point()..old_insertion_point);
+                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                        }
+                    }
+                    _ => {}
+                },
+                Event::Key(KeyEvent {
+                    code,
+                    modifiers: KeyModifiers::ALT,
+                }) => match code {
+                    KeyCode::Char('b') => {
+                        buffer.move_word_left();
+                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                    }
+                    KeyCode::Char('f') => {
+                        buffer.move_word_right();
+                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                    }
+                    KeyCode::Char('d') => {
+                        let old_insertion_point = buffer.get_insertion_point();
+                        buffer.move_word_right();
+                        if buffer.get_insertion_point() > old_insertion_point {
+                            cut_buffer.replace_range(
+                                ..,
+                                &buffer.get_buffer()
+                                    [old_insertion_point..buffer.get_insertion_point()],
+                            );
+                            buffer.clear_range(old_insertion_point..buffer.get_insertion_point());
+                            buffer.set_insertion_point(old_insertion_point);
+                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                        }
+                    }
+                    KeyCode::Left => {
+                        if buffer.get_insertion_point() > 0 {
+                            // If the ALT modifier is set, we want to jump words for more
+                            // natural editing. Jumping words basically means: move to next
+                            // whitespace in the given direction.
+                            buffer.move_word_left();
+                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                        }
+                    }
+                    KeyCode::Right => {
+                        if buffer.get_insertion_point() < buffer.get_buffer_len() {
+                            buffer.move_word_right();
+                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                        }
+                    }
+                    _ => {}
+                },
+                Event::Key(KeyEvent { code, modifiers: _ }) => {
+                    match code {
+                        KeyCode::Char(c) => {
+                            buffer.insert_char(buffer.get_insertion_point(), c);
                             buffer.inc_insertion_point();
+
                             buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                         }
-                        KeyCode::Char('c') => {
-                            buffer.clear();
-                            stdout.queue(Print('\n'))?.queue(MoveToColumn(1))?.flush()?;
-                            break 'input;
-                        }
-                        KeyCode::Char('h') => {
+                        KeyCode::Backspace => {
                             let insertion_point = buffer.get_insertion_point();
                             if insertion_point == buffer.get_buffer_len() && !buffer.is_empty() {
+                                // buffer.dec_insertion_point();
                                 buffer.pop();
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             } else if insertion_point < buffer.get_buffer_len()
@@ -186,191 +270,105 @@ fn main() -> Result<()> {
                                 buffer.dec_insertion_point();
                                 let insertion_point = buffer.get_insertion_point();
                                 buffer.remove_char(insertion_point);
+
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             }
                         }
-                        KeyCode::Char('w') => {
-                            let old_insertion_point = buffer.get_insertion_point();
-                            buffer.move_word_left();
-                            if buffer.get_insertion_point() < old_insertion_point {
-                                cut_buffer.replace_range(
-                                    ..,
-                                    &buffer.get_buffer()
-                                        [buffer.get_insertion_point()..old_insertion_point],
-                                );
-                                buffer
-                                    .clear_range(buffer.get_insertion_point()..old_insertion_point);
+                        KeyCode::Delete => {
+                            let insertion_point = buffer.get_insertion_point();
+                            if insertion_point < buffer.get_buffer_len() && !buffer.is_empty() {
+                                buffer.remove_char(insertion_point);
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             }
                         }
-                        _ => {}
-                    },
-                    Event::Key(KeyEvent {
-                        code,
-                        modifiers: KeyModifiers::ALT,
-                    }) => match code {
-                        KeyCode::Char('b') => {
-                            buffer.move_word_left();
+                        KeyCode::Home => {
+                            buffer.set_insertion_point(0);
                             buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                         }
-                        KeyCode::Char('f') => {
-                            buffer.move_word_right();
+                        KeyCode::End => {
+                            let buffer_len = buffer.get_buffer_len();
+                            buffer.set_insertion_point(buffer_len);
                             buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                         }
-                        KeyCode::Char('d') => {
-                            let old_insertion_point = buffer.get_insertion_point();
-                            buffer.move_word_right();
-                            if buffer.get_insertion_point() > old_insertion_point {
-                                cut_buffer.replace_range(
-                                    ..,
-                                    &buffer.get_buffer()
-                                        [old_insertion_point..buffer.get_insertion_point()],
-                                );
-                                buffer
-                                    .clear_range(old_insertion_point..buffer.get_insertion_point());
-                                buffer.set_insertion_point(old_insertion_point);
+                        KeyCode::Enter => {
+                            if buffer.get_buffer() == "exit" {
+                                break 'repl;
+                            } else {
+                                if history.len() + 1 == HISTORY_SIZE {
+                                    // History is "full", so we delete the oldest entry first,
+                                    // before adding a new one.
+                                    history.pop_back();
+                                }
+                                history.push_front(String::from(buffer.get_buffer()));
+                                has_history = true;
+                                // reset the history cursor - we want to start at the bottom of the
+                                // history again.
+                                history_cursor = -1;
+                                print_message(
+                                    &mut stdout,
+                                    &format!("Our buffer: {}", buffer.get_buffer()),
+                                )?;
+                                buffer.clear();
+                                buffer.set_insertion_point(0);
+                                break 'input;
+                            }
+                        }
+                        KeyCode::Up => {
+                            // Up means: navigate through the history.
+                            if has_history && history_cursor < (history.len() as i64 - 1) {
+                                history_cursor += 1;
+                                let history_entry =
+                                    history.get(history_cursor as usize).unwrap().clone();
+                                buffer.set_buffer(history_entry.clone());
+                                buffer.move_to_end();
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             }
+                        }
+                        KeyCode::Down => {
+                            // Down means: navigate forward through the history. If we reached the
+                            // bottom of the history, we clear the buffer, to make it feel like
+                            // zsh/bash/whatever
+                            if history_cursor >= 0 {
+                                history_cursor -= 1;
+                            }
+                            let new_buffer = if history_cursor < 0 {
+                                String::new()
+                            } else {
+                                // We can be sure that we always have an entry on hand, that's why
+                                // unwrap is fine.
+                                history.get(history_cursor as usize).unwrap().clone()
+                            };
+
+                            buffer.set_buffer(new_buffer.clone());
+                            buffer.move_to_end();
+                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                         }
                         KeyCode::Left => {
                             if buffer.get_insertion_point() > 0 {
                                 // If the ALT modifier is set, we want to jump words for more
                                 // natural editing. Jumping words basically means: move to next
                                 // whitespace in the given direction.
-                                buffer.move_word_left();
+                                buffer.dec_insertion_point();
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             }
                         }
                         KeyCode::Right => {
                             if buffer.get_insertion_point() < buffer.get_buffer_len() {
-                                buffer.move_word_right();
+                                buffer.inc_insertion_point();
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             }
                         }
                         _ => {}
-                    },
-                    Event::Key(KeyEvent { code, modifiers: _ }) => {
-                        match code {
-                            KeyCode::Char(c) => {
-                                buffer.insert_char(buffer.get_insertion_point(), c);
-                                buffer.inc_insertion_point();
-
-                                buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                            }
-                            KeyCode::Backspace => {
-                                let insertion_point = buffer.get_insertion_point();
-                                if insertion_point == buffer.get_buffer_len() && !buffer.is_empty()
-                                {
-                                    // buffer.dec_insertion_point();
-                                    buffer.pop();
-                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                                } else if insertion_point < buffer.get_buffer_len()
-                                    && insertion_point > 0
-                                    && !buffer.is_empty()
-                                {
-                                    buffer.dec_insertion_point();
-                                    let insertion_point = buffer.get_insertion_point();
-                                    buffer.remove_char(insertion_point);
-
-                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                                }
-                            }
-                            KeyCode::Delete => {
-                                let insertion_point = buffer.get_insertion_point();
-                                if insertion_point < buffer.get_buffer_len() && !buffer.is_empty() {
-                                    buffer.remove_char(insertion_point);
-                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                                }
-                            }
-                            KeyCode::Home => {
-                                buffer.set_insertion_point(0);
-                                buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                            }
-                            KeyCode::End => {
-                                let buffer_len = buffer.get_buffer_len();
-                                buffer.set_insertion_point(buffer_len);
-                                buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                            }
-                            KeyCode::Enter => {
-                                if buffer.get_buffer() == "exit" {
-                                    break 'repl;
-                                } else {
-                                    if history.len() + 1 == HISTORY_SIZE {
-                                        // History is "full", so we delete the oldest entry first,
-                                        // before adding a new one.
-                                        history.pop_back();
-                                    }
-                                    history.push_front(String::from(buffer.get_buffer()));
-                                    has_history = true;
-                                    // reset the history cursor - we want to start at the bottom of the
-                                    // history again.
-                                    history_cursor = -1;
-                                    print_message(
-                                        &mut stdout,
-                                        &format!("Our buffer: {}", buffer.get_buffer()),
-                                    )?;
-                                    buffer.clear();
-                                    buffer.set_insertion_point(0);
-                                    break 'input;
-                                }
-                            }
-                            KeyCode::Up => {
-                                // Up means: navigate through the history.
-                                if has_history && history_cursor < (history.len() as i64 - 1) {
-                                    history_cursor += 1;
-                                    let history_entry =
-                                        history.get(history_cursor as usize).unwrap().clone();
-                                    buffer.set_buffer(history_entry.clone());
-                                    buffer.move_to_end();
-                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                                }
-                            }
-                            KeyCode::Down => {
-                                // Down means: navigate forward through the history. If we reached the
-                                // bottom of the history, we clear the buffer, to make it feel like
-                                // zsh/bash/whatever
-                                if history_cursor >= 0 {
-                                    history_cursor -= 1;
-                                }
-                                let new_buffer = if history_cursor < 0 {
-                                    String::new()
-                                } else {
-                                    // We can be sure that we always have an entry on hand, that's why
-                                    // unwrap is fine.
-                                    history.get(history_cursor as usize).unwrap().clone()
-                                };
-
-                                buffer.set_buffer(new_buffer.clone());
-                                buffer.move_to_end();
-                                buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                            }
-                            KeyCode::Left => {
-                                if buffer.get_insertion_point() > 0 {
-                                    // If the ALT modifier is set, we want to jump words for more
-                                    // natural editing. Jumping words basically means: move to next
-                                    // whitespace in the given direction.
-                                    buffer.dec_insertion_point();
-                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                                }
-                            }
-                            KeyCode::Right => {
-                                if buffer.get_insertion_point() < buffer.get_buffer_len() {
-                                    buffer.inc_insertion_point();
-                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                                }
-                            }
-                            _ => {}
-                        };
-                    }
-                    Event::Mouse(event) => {
-                        print_message(&mut stdout, &format!("{:?}", event))?;
-                    }
-                    Event::Resize(width, height) => {
-                        print_message(
-                            &mut stdout,
-                            &format!("width: {} and height: {}", width, height),
-                        )?;
-                    }
+                    };
+                }
+                Event::Mouse(event) => {
+                    print_message(&mut stdout, &format!("{:?}", event))?;
+                }
+                Event::Resize(width, height) => {
+                    print_message(
+                        &mut stdout,
+                        &format!("width: {} and height: {}", width, height),
+                    )?;
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 use std::io::{stdout, Write};
+use std::time::Duration;
 
 use crossterm::{
     cursor::{position, MoveToColumn, MoveToNextLine, RestorePosition, SavePosition},
-    event::read,
-    event::{Event, KeyCode, KeyEvent, KeyModifiers},
+    event::{poll, read, Event, KeyCode, KeyEvent, KeyModifiers},
     style::{Color, Print, ResetColor, SetForegroundColor},
     terminal::{self, Clear, ClearType},
     ExecutableCommand, QueueableCommand, Result,
@@ -53,176 +53,130 @@ fn buffer_repaint(stdout: &mut Stdout, buffer: &LineBuffer, prompt_offset: u16) 
     Ok(())
 }
 
+// this fn is totally ripped off from crossterm's examples
+// it's really a diagnostic routine to see if crossterm is
+// even seeing the events. if you press a key and no events
+// are printed, it's a good chance your terminal is eating
+// those events.
+fn print_events(stdout: &mut Stdout) -> Result<()> {
+    loop {
+        // Wait up to 5s for another event
+        if poll(Duration::from_millis(5_000))? {
+            // It's guaranteed that read() wont block if `poll` returns `Ok(true)`
+            let event = read()?;
+
+            // just reuse the print_message fn to show events
+            print_message(stdout, &format!("Event::{:?}", event))?;
+
+            // hit the esc key to git out
+            if event == Event::Key(KeyCode::Esc.into()) {
+                break;
+            }
+        } else {
+            // Timeout expired, no event for 5s
+            print_message(stdout, "Waiting for you to type...")?;
+        }
+    }
+
+    Ok(())
+}
+
 fn main() -> Result<()> {
     let mut stdout = stdout();
 
     terminal::enable_raw_mode()?;
+    // quick command like parameter handling
+    let args: Vec<String> = std::env::args().collect();
+    // if -k is passed, show the events
+    if args.len() > 1 && args[1] == "-k" {
+        print_message(&mut stdout, "Ready to print events:")?;
+        print_events(&mut stdout)?;
+    } else {
+        let mut buffer = LineBuffer::new();
+        let mut history = VecDeque::with_capacity(HISTORY_SIZE);
+        let mut history_cursor = -1i64;
+        let mut has_history = false;
+        let mut cut_buffer = String::new();
 
-    let mut buffer = LineBuffer::new();
-    let mut history = VecDeque::with_capacity(HISTORY_SIZE);
-    let mut history_cursor = -1i64;
-    let mut has_history = false;
-    let mut cut_buffer = String::new();
+        'repl: loop {
+            // print our prompt
+            stdout
+                .execute(SetForegroundColor(Color::Blue))?
+                .execute(Print("> "))?
+                .execute(ResetColor)?;
 
-    'repl: loop {
-        // print our prompt
-        stdout
-            .execute(SetForegroundColor(Color::Blue))?
-            .execute(Print("> "))?
-            .execute(ResetColor)?;
+            // set where the input begins
+            let (mut prompt_offset, _) = position()?;
+            prompt_offset += 1;
 
-        // set where the input begins
-        let (mut prompt_offset, _) = position()?;
-        prompt_offset += 1;
-
-        'input: loop {
-            match read()? {
-                Event::Key(KeyEvent {
-                    code,
-                    modifiers: KeyModifiers::CONTROL,
-                }) => match code {
-                    KeyCode::Char('d') => {
-                        if buffer.get_buffer().is_empty() {
-                            stdout.queue(MoveToNextLine(1))?.queue(Print("exit"))?;
-                            break 'repl;
-                        } else {
-                            let insertion_point = buffer.get_insertion_point();
-                            if insertion_point < buffer.get_buffer_len() && !buffer.is_empty() {
-                                buffer.remove_char(insertion_point);
+            'input: loop {
+                match read()? {
+                    Event::Key(KeyEvent {
+                        code,
+                        modifiers: KeyModifiers::CONTROL,
+                    }) => match code {
+                        KeyCode::Char('d') => {
+                            if buffer.get_buffer().is_empty() {
+                                stdout.queue(MoveToNextLine(1))?.queue(Print("exit"))?;
+                                break 'repl;
+                            } else {
+                                let insertion_point = buffer.get_insertion_point();
+                                if insertion_point < buffer.get_buffer_len() && !buffer.is_empty() {
+                                    buffer.remove_char(insertion_point);
+                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                                }
+                            }
+                        }
+                        KeyCode::Char('a') => {
+                            buffer.set_insertion_point(0);
+                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                        }
+                        KeyCode::Char('e') => {
+                            let buffer_len = buffer.get_buffer_len();
+                            buffer.set_insertion_point(buffer_len);
+                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                        }
+                        KeyCode::Char('k') => {
+                            let cut_slice = &buffer.get_buffer()[buffer.get_insertion_point()..];
+                            if !cut_slice.is_empty() {
+                                cut_buffer.replace_range(.., cut_slice);
+                                buffer.clear_to_end();
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             }
                         }
-                    }
-                    KeyCode::Char('a') => {
-                        buffer.set_insertion_point(0);
-                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                    }
-                    KeyCode::Char('e') => {
-                        let buffer_len = buffer.get_buffer_len();
-                        buffer.set_insertion_point(buffer_len);
-                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                    }
-                    KeyCode::Char('k') => {
-                        let cut_slice = &buffer.get_buffer()[buffer.get_insertion_point()..];
-                        if !cut_slice.is_empty() {
-                            cut_buffer.replace_range(.., cut_slice);
-                            buffer.clear_to_end();
-                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                        KeyCode::Char('u') => {
+                            if buffer.get_insertion_point() > 0 {
+                                cut_buffer.replace_range(
+                                    ..,
+                                    &buffer.get_buffer()[..buffer.get_insertion_point()],
+                                );
+                                buffer.clear_to_insertion_point();
+                                buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                            }
                         }
-                    }
-                    KeyCode::Char('u') => {
-                        if buffer.get_insertion_point() > 0 {
-                            cut_buffer.replace_range(
-                                ..,
-                                &buffer.get_buffer()[..buffer.get_insertion_point()],
+                        KeyCode::Char('y') => {
+                            buffer.insert_str(buffer.get_insertion_point(), &cut_buffer);
+                            buffer.set_insertion_point(
+                                buffer.get_insertion_point() + cut_buffer.len(),
                             );
-                            buffer.clear_to_insertion_point();
                             buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                         }
-                    }
-                    KeyCode::Char('y') => {
-                        buffer.insert_str(buffer.get_insertion_point(), &cut_buffer);
-                        buffer.set_insertion_point(buffer.get_insertion_point() + cut_buffer.len());
-                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                    }
-                    KeyCode::Char('b') => {
-                        buffer.dec_insertion_point();
-                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                    }
-                    KeyCode::Char('f') => {
-                        buffer.inc_insertion_point();
-                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                    }
-                    KeyCode::Char('c') => {
-                        buffer.clear();
-                        stdout.queue(Print('\n'))?.queue(MoveToColumn(1))?.flush()?;
-                        break 'input;
-                    }
-                    KeyCode::Char('h') => {
-                        let insertion_point = buffer.get_insertion_point();
-                        if insertion_point == buffer.get_buffer_len() && !buffer.is_empty() {
-                            buffer.pop();
-                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                        } else if insertion_point < buffer.get_buffer_len()
-                            && insertion_point > 0
-                            && !buffer.is_empty()
-                        {
+                        KeyCode::Char('b') => {
                             buffer.dec_insertion_point();
-                            let insertion_point = buffer.get_insertion_point();
-                            buffer.remove_char(insertion_point);
                             buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                         }
-                    }
-                    KeyCode::Char('w') => {
-                        let old_insertion_point = buffer.get_insertion_point();
-                        buffer.move_word_left();
-                        if buffer.get_insertion_point() < old_insertion_point {
-                            cut_buffer.replace_range(
-                                ..,
-                                &buffer.get_buffer()
-                                    [buffer.get_insertion_point()..old_insertion_point],
-                            );
-                            buffer.clear_range(buffer.get_insertion_point()..old_insertion_point);
-                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                        }
-                    }
-                    _ => {}
-                },
-                Event::Key(KeyEvent {
-                    code,
-                    modifiers: KeyModifiers::ALT,
-                }) => match code {
-                    KeyCode::Char('b') => {
-                        buffer.move_word_left();
-                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                    }
-                    KeyCode::Char('f') => {
-                        buffer.move_word_right();
-                        buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                    }
-                    KeyCode::Char('d') => {
-                        let old_insertion_point = buffer.get_insertion_point();
-                        buffer.move_word_right();
-                        if buffer.get_insertion_point() > old_insertion_point {
-                            cut_buffer.replace_range(
-                                ..,
-                                &buffer.get_buffer()
-                                    [old_insertion_point..buffer.get_insertion_point()],
-                            );
-                            buffer.clear_range(old_insertion_point..buffer.get_insertion_point());
-                            buffer.set_insertion_point(old_insertion_point);
-                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                        }
-                    }
-                    KeyCode::Left => {
-                        if buffer.get_insertion_point() > 0 {
-                            // If the ALT modifier is set, we want to jump words for more
-                            // natural editing. Jumping words basically means: move to next
-                            // whitespace in the given direction.
-                            buffer.move_word_left();
-                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                        }
-                    }
-                    KeyCode::Right => {
-                        if buffer.get_insertion_point() < buffer.get_buffer_len() {
-                            buffer.move_word_right();
-                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
-                        }
-                    }
-                    _ => {}
-                },
-                Event::Key(KeyEvent { code, modifiers: _ }) => {
-                    match code {
-                        KeyCode::Char(c) => {
-                            buffer.insert_char(buffer.get_insertion_point(), c);
+                        KeyCode::Char('f') => {
                             buffer.inc_insertion_point();
-
                             buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                         }
-                        KeyCode::Backspace => {
+                        KeyCode::Char('c') => {
+                            buffer.clear();
+                            stdout.queue(Print('\n'))?.queue(MoveToColumn(1))?.flush()?;
+                            break 'input;
+                        }
+                        KeyCode::Char('h') => {
                             let insertion_point = buffer.get_insertion_point();
                             if insertion_point == buffer.get_buffer_len() && !buffer.is_empty() {
-                                // buffer.dec_insertion_point();
                                 buffer.pop();
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             } else if insertion_point < buffer.get_buffer_len()
@@ -232,110 +186,195 @@ fn main() -> Result<()> {
                                 buffer.dec_insertion_point();
                                 let insertion_point = buffer.get_insertion_point();
                                 buffer.remove_char(insertion_point);
-
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             }
                         }
-                        KeyCode::Delete => {
-                            let insertion_point = buffer.get_insertion_point();
-                            if insertion_point < buffer.get_buffer_len() && !buffer.is_empty() {
-                                buffer.remove_char(insertion_point);
+                        KeyCode::Char('w') => {
+                            let old_insertion_point = buffer.get_insertion_point();
+                            buffer.move_word_left();
+                            if buffer.get_insertion_point() < old_insertion_point {
+                                cut_buffer.replace_range(
+                                    ..,
+                                    &buffer.get_buffer()
+                                        [buffer.get_insertion_point()..old_insertion_point],
+                                );
+                                buffer
+                                    .clear_range(buffer.get_insertion_point()..old_insertion_point);
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             }
                         }
-                        KeyCode::Home => {
-                            buffer.set_insertion_point(0);
+                        _ => {}
+                    },
+                    Event::Key(KeyEvent {
+                        code,
+                        modifiers: KeyModifiers::ALT,
+                    }) => match code {
+                        KeyCode::Char('b') => {
+                            buffer.move_word_left();
                             buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                         }
-                        KeyCode::End => {
-                            let buffer_len = buffer.get_buffer_len();
-                            buffer.set_insertion_point(buffer_len);
+                        KeyCode::Char('f') => {
+                            buffer.move_word_right();
                             buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                         }
-                        KeyCode::Enter => {
-                            if buffer.get_buffer() == "exit" {
-                                break 'repl;
-                            } else {
-                                if history.len() + 1 == HISTORY_SIZE {
-                                    // History is "full", so we delete the oldest entry first,
-                                    // before adding a new one.
-                                    history.pop_back();
-                                }
-                                history.push_front(String::from(buffer.get_buffer()));
-                                has_history = true;
-                                // reset the history cursor - we want to start at the bottom of the
-                                // history again.
-                                history_cursor = -1;
-                                print_message(
-                                    &mut stdout,
-                                    &format!("Our buffer: {}", buffer.get_buffer()),
-                                )?;
-                                buffer.clear();
-                                buffer.set_insertion_point(0);
-                                break 'input;
-                            }
-                        }
-                        KeyCode::Up => {
-                            // Up means: navigate through the history.
-                            if has_history && history_cursor < (history.len() as i64 - 1) {
-                                history_cursor += 1;
-                                let history_entry =
-                                    history.get(history_cursor as usize).unwrap().clone();
-                                buffer.set_buffer(history_entry.clone());
-                                buffer.move_to_end();
+                        KeyCode::Char('d') => {
+                            let old_insertion_point = buffer.get_insertion_point();
+                            buffer.move_word_right();
+                            if buffer.get_insertion_point() > old_insertion_point {
+                                cut_buffer.replace_range(
+                                    ..,
+                                    &buffer.get_buffer()
+                                        [old_insertion_point..buffer.get_insertion_point()],
+                                );
+                                buffer
+                                    .clear_range(old_insertion_point..buffer.get_insertion_point());
+                                buffer.set_insertion_point(old_insertion_point);
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             }
-                        }
-                        KeyCode::Down => {
-                            // Down means: navigate forward through the history. If we reached the
-                            // bottom of the history, we clear the buffer, to make it feel like
-                            // zsh/bash/whatever
-                            if history_cursor >= 0 {
-                                history_cursor -= 1;
-                            }
-                            let new_buffer = if history_cursor < 0 {
-                                String::new()
-                            } else {
-                                // We can be sure that we always have an entry on hand, that's why
-                                // unwrap is fine.
-                                history.get(history_cursor as usize).unwrap().clone()
-                            };
-
-                            buffer.set_buffer(new_buffer.clone());
-                            buffer.move_to_end();
-                            buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                         }
                         KeyCode::Left => {
                             if buffer.get_insertion_point() > 0 {
                                 // If the ALT modifier is set, we want to jump words for more
                                 // natural editing. Jumping words basically means: move to next
                                 // whitespace in the given direction.
-                                buffer.dec_insertion_point();
+                                buffer.move_word_left();
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             }
                         }
                         KeyCode::Right => {
                             if buffer.get_insertion_point() < buffer.get_buffer_len() {
-                                buffer.inc_insertion_point();
+                                buffer.move_word_right();
                                 buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
                             }
                         }
                         _ => {}
-                    };
-                }
-                Event::Mouse(event) => {
-                    print_message(&mut stdout, &format!("{:?}", event))?;
-                }
-                Event::Resize(width, height) => {
-                    print_message(
-                        &mut stdout,
-                        &format!("width: {} and height: {}", width, height),
-                    )?;
+                    },
+                    Event::Key(KeyEvent { code, modifiers: _ }) => {
+                        match code {
+                            KeyCode::Char(c) => {
+                                buffer.insert_char(buffer.get_insertion_point(), c);
+                                buffer.inc_insertion_point();
+
+                                buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                            }
+                            KeyCode::Backspace => {
+                                let insertion_point = buffer.get_insertion_point();
+                                if insertion_point == buffer.get_buffer_len() && !buffer.is_empty()
+                                {
+                                    // buffer.dec_insertion_point();
+                                    buffer.pop();
+                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                                } else if insertion_point < buffer.get_buffer_len()
+                                    && insertion_point > 0
+                                    && !buffer.is_empty()
+                                {
+                                    buffer.dec_insertion_point();
+                                    let insertion_point = buffer.get_insertion_point();
+                                    buffer.remove_char(insertion_point);
+
+                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                                }
+                            }
+                            KeyCode::Delete => {
+                                let insertion_point = buffer.get_insertion_point();
+                                if insertion_point < buffer.get_buffer_len() && !buffer.is_empty() {
+                                    buffer.remove_char(insertion_point);
+                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                                }
+                            }
+                            KeyCode::Home => {
+                                buffer.set_insertion_point(0);
+                                buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                            }
+                            KeyCode::End => {
+                                let buffer_len = buffer.get_buffer_len();
+                                buffer.set_insertion_point(buffer_len);
+                                buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                            }
+                            KeyCode::Enter => {
+                                if buffer.get_buffer() == "exit" {
+                                    break 'repl;
+                                } else {
+                                    if history.len() + 1 == HISTORY_SIZE {
+                                        // History is "full", so we delete the oldest entry first,
+                                        // before adding a new one.
+                                        history.pop_back();
+                                    }
+                                    history.push_front(String::from(buffer.get_buffer()));
+                                    has_history = true;
+                                    // reset the history cursor - we want to start at the bottom of the
+                                    // history again.
+                                    history_cursor = -1;
+                                    print_message(
+                                        &mut stdout,
+                                        &format!("Our buffer: {}", buffer.get_buffer()),
+                                    )?;
+                                    buffer.clear();
+                                    buffer.set_insertion_point(0);
+                                    break 'input;
+                                }
+                            }
+                            KeyCode::Up => {
+                                // Up means: navigate through the history.
+                                if has_history && history_cursor < (history.len() as i64 - 1) {
+                                    history_cursor += 1;
+                                    let history_entry =
+                                        history.get(history_cursor as usize).unwrap().clone();
+                                    buffer.set_buffer(history_entry.clone());
+                                    buffer.move_to_end();
+                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                                }
+                            }
+                            KeyCode::Down => {
+                                // Down means: navigate forward through the history. If we reached the
+                                // bottom of the history, we clear the buffer, to make it feel like
+                                // zsh/bash/whatever
+                                if history_cursor >= 0 {
+                                    history_cursor -= 1;
+                                }
+                                let new_buffer = if history_cursor < 0 {
+                                    String::new()
+                                } else {
+                                    // We can be sure that we always have an entry on hand, that's why
+                                    // unwrap is fine.
+                                    history.get(history_cursor as usize).unwrap().clone()
+                                };
+
+                                buffer.set_buffer(new_buffer.clone());
+                                buffer.move_to_end();
+                                buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                            }
+                            KeyCode::Left => {
+                                if buffer.get_insertion_point() > 0 {
+                                    // If the ALT modifier is set, we want to jump words for more
+                                    // natural editing. Jumping words basically means: move to next
+                                    // whitespace in the given direction.
+                                    buffer.dec_insertion_point();
+                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                                }
+                            }
+                            KeyCode::Right => {
+                                if buffer.get_insertion_point() < buffer.get_buffer_len() {
+                                    buffer.inc_insertion_point();
+                                    buffer_repaint(&mut stdout, &buffer, prompt_offset)?;
+                                }
+                            }
+                            _ => {}
+                        };
+                    }
+                    Event::Mouse(event) => {
+                        print_message(&mut stdout, &format!("{:?}", event))?;
+                    }
+                    Event::Resize(width, height) => {
+                        print_message(
+                            &mut stdout,
+                            &format!("width: {} and height: {}", width, height),
+                        )?;
+                    }
                 }
             }
         }
     }
-
     terminal::disable_raw_mode()?;
 
     println!();


### PR DESCRIPTION
If ran with `cargo run -- -k` reedline with execute in diagnostic mode in order to show you the events that are captured from the keyboard. This is just a quick hack that allows you to see if crossterm can see the events.

If ran with `cargo run` reedline executes normally.

No work was done to formalize command line parameter parsing. This is just a quick hack to help me figure out that iterm2 appears to be eating my up and down arrow event on my mac.

Looking at the diff, it looks like a lot of code changed but i really only added one fn `print_events` and a few lines in `main`. The rest are `fmt` changing the format.