### PR TITLE
small refactor

### DIFF
--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -1,0 +1,31 @@
+use crate::engine::print_message;
+use crossterm::event::{poll, read, Event, KeyCode};
+use std::{io::Stdout, time::Duration};
+
+// this fn is totally ripped off from crossterm's examples
+// it's really a diagnostic routine to see if crossterm is
+// even seeing the events. if you press a key and no events
+// are printed, it's a good chance your terminal is eating
+// those events.
+pub fn print_events(stdout: &mut Stdout) -> Result<(), crossterm::ErrorKind> {
+    loop {
+        // Wait up to 5s for another event
+        if poll(Duration::from_millis(5_000))? {
+            // It's guaranteed that read() wont block if `poll` returns `Ok(true)`
+            let event = read()?;
+
+            // just reuse the print_message fn to show events
+            print_message(stdout, &format!("Event::{:?}", event))?;
+
+            // hit the esc key to git out
+            if event == Event::Key(KeyCode::Esc.into()) {
+                break;
+            }
+        } else {
+            // Timeout expired, no event for 5s
+            print_message(stdout, "Waiting for you to type...")?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,45 +1,15 @@
-use std::io::stdout;
-use std::time::Duration;
-
-use std::io::Stdout;
-
 use crossterm::{
-    event::{poll, read, Event, KeyCode},
     terminal::{self},
     Result,
 };
+use std::io::stdout;
 mod line_buffer;
 
 mod engine;
 use engine::{print_crlf, print_message, Engine, Signal};
 
-// this fn is totally ripped off from crossterm's examples
-// it's really a diagnostic routine to see if crossterm is
-// even seeing the events. if you press a key and no events
-// are printed, it's a good chance your terminal is eating
-// those events.
-fn print_events(stdout: &mut Stdout) -> Result<()> {
-    loop {
-        // Wait up to 5s for another event
-        if poll(Duration::from_millis(5_000))? {
-            // It's guaranteed that read() wont block if `poll` returns `Ok(true)`
-            let event = read()?;
-
-            // just reuse the print_message fn to show events
-            print_message(stdout, &format!("Event::{:?}", event))?;
-
-            // hit the esc key to git out
-            if event == Event::Key(KeyCode::Esc.into()) {
-                break;
-            }
-        } else {
-            // Timeout expired, no event for 5s
-            print_message(stdout, "Waiting for you to type...")?;
-        }
-    }
-
-    Ok(())
-}
+mod diagnostic;
+use diagnostic::print_events;
 
 fn main() -> Result<()> {
     let mut stdout = stdout();


### PR DESCRIPTION
* move `print_events` to it's own diagnostic crate to declutter main.rs.
* cleanup a bit of code