### PR TITLE
Simplify prompt code and handle narrow terminals

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -93,8 +93,7 @@ pub fn clear_screen(stdout: &mut Stdout) -> Result<()> {
 }
 
 fn queue_prompt(stdout: &mut Stdout) -> Result<()> {
-    let mut prompt = Prompt::new();
-    prompt.set_prompt_indicator(PROMPT_INDICATOR.to_string());
+    let mut prompt = Prompt::new(PROMPT_INDICATOR, 1);
 
     // print our prompt
     stdout


### PR DESCRIPTION
When there isn't enough room for both the left and right prompts, only
show the left one. Also truncate the left prompt if it's too wide.