### PR TITLE
Refactor Clipboard behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,7 @@ crossterm = "0.19.0"
 unicode-segmentation = "1.7.1"
 chrono = "0.4.19"
 unicode-width = "0.1.8"
-clipboard = "0.5.0"
+clipboard = { version = "0.5.0", optional = true }
+
+[features]
+system_clipboard = ["clipboard"]

--- a/src/clip_buffer.rs
+++ b/src/clip_buffer.rs
@@ -1,0 +1,102 @@
+pub trait Clipboard {
+    fn set(&mut self, content: &str);
+
+    fn get(&mut self) -> String;
+
+    fn clear(&mut self) {
+        self.set("");
+    }
+
+    fn len(&mut self) -> usize {
+        self.get().len()
+    }
+
+    fn is_empty(&mut self) -> bool {
+        self.get().is_empty()
+    }
+}
+
+#[derive(Default)]
+pub struct LocalClipboard {
+    content: String,
+}
+
+impl LocalClipboard {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Clipboard for LocalClipboard {
+    fn set(&mut self, content: &str) {
+        self.content = content.to_owned();
+    }
+
+    fn get(&mut self) -> String {
+        self.content.clone()
+    }
+}
+
+#[cfg(feature = "system_clipboard")]
+pub use system_clipboard::SystemClipboard;
+
+#[cfg(feature = "system_clipboard")]
+pub fn get_default_clipboard() -> SystemClipboard {
+    SystemClipboard::new()
+}
+
+#[cfg(not(feature = "system_clipboard"))]
+pub fn get_default_clipboard() -> LocalClipboard {
+    LocalClipboard::new()
+}
+
+#[cfg(feature = "system_clipboard")]
+mod system_clipboard {
+    use super::*;
+    use clipboard::{ClipboardContext, ClipboardProvider};
+    pub struct SystemClipboard {
+        cb: ClipboardContext,
+    }
+
+    impl SystemClipboard {
+        pub fn new() -> Self {
+            let cb = ClipboardProvider::new().unwrap();
+            SystemClipboard { cb }
+        }
+    }
+
+    impl Clipboard for SystemClipboard {
+        fn set(&mut self, content: &str) {
+            let _ = self.cb.set_contents(content.to_owned());
+        }
+
+        fn get(&mut self) -> String {
+            self.cb.get_contents().unwrap_or_default()
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::{get_default_clipboard, Clipboard};
+    #[test]
+    fn reads_back() {
+        let mut cb = get_default_clipboard();
+        // If the system clipboard is used we want to persist it for the user
+        let previous_state = cb.get();
+
+        // Actual test
+        cb.set("test");
+        assert_eq!(cb.len(), 4);
+        assert_eq!(cb.get(), "test".to_owned());
+        cb.clear();
+        assert!(cb.is_empty());
+
+
+        // Restore!
+
+        cb.set(&previous_state);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+mod clip_buffer;
+
 mod engine;
 pub use engine::{Reedline, Signal};
 


### PR DESCRIPTION
The clipboard crate breaks the CI in a non GUI context. Make use of it
optional by feature flag `system_clipboard`.
Clipboard could be changed during runtime based on trait.

Additional fix: read back from system clipboard