### PR TITLE
Add resize logic and history prefix

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -5,9 +5,7 @@ TODO:
 * Documention
   * README
   * Documenting of all public functions and structs and traits
-* Support resize
-  * We should detect the resize event, then start back at the beginning of where
-    the prompt began, redraw the prompt and then redraw the user input up to now
+    * At least some of the public functions are now documented
 * Syntax highlighting
 * Multiline support
 * Validation
@@ -41,6 +39,7 @@ X Editing engine
   X Unicode w/ joiner support for removal
 X History
 X Up/down history
+X Support for persisting history file
 X Home/end
 X Refactor keypresses to flush at the end
 X Ctrl-A, Ctrl-K, etc
@@ -53,4 +52,8 @@ X Split Engine into its isolated parts
   X Maybe cut buffer. Question: do we want to connect to the OS's clipboard?
   X History is persisted to disk.
 X Make Prompt trait and make prompt configurable
+X Support resize
+  * We should detect the resize event, then start back at the beginning of where
+    the prompt began, redraw the prompt and then redraw the user input up to now
+X prefix-based history navigation
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! ## Are we prompt yet? (Development status)
 //!
-//! This crate is currently under active development in Jonathan Turner's
+//! This crate is currently under active development in JT's
 //! [live-coding streams](https://www.twitch.tv/jntrnr). If you want to see a
 //! feature, jump by the streams, file an
 //! [issue](https://github.com/jonathandturner/reedline/issues) or contribute a

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -52,6 +52,10 @@ impl LineBuffer {
         self.insertion_point = pos;
     }
 
+    pub fn get_buffer(&self) -> String {
+        self.lines[self.insertion_point.line].clone()
+    }
+
     /// Output the current line in the multiline buffer
     pub fn insertion_line(&self) -> &str {
         &self.lines[self.insertion_point.line]


### PR DESCRIPTION
This adds two separate bits of functionality from the stream:

* Resize now properly re-renders the prompt and user input
* History up/down navigation will use the prefix of the search typed by the user before using up/down. This matches fish's prefixed history navigation