### PR TITLE
Fix unhandled shift case

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -712,7 +712,8 @@ impl Reedline {
                         (KeyModifiers::CONTROL, KeyCode::Char('l')) => {
                             return Ok(Signal::CtrlL);
                         }
-                        (KeyModifiers::NONE, KeyCode::Char(c)) => {
+                        (KeyModifiers::NONE, KeyCode::Char(c))
+                        | (KeyModifiers::SHIFT, KeyCode::Char(c)) => {
                             let line_start = if self.insertion_point().line == 0 {
                                 prompt_offset.0
                             } else {


### PR DESCRIPTION
With the [new commit](https://github.com/jonathandturner/reedline/commit/e0714819e47463c0b7b81d33649b6f1e6ad9127e), the KeyModifiers::SHIFT case was not handled in read_line_helper function inside engine.rs; the choice was either to map all the individual characters in the default_keybindings function within keybindings.rs or to handle the case along with the normal characters; since there were no particular reasons to choose the first option I chose the fastest.