### PR TITLE
Various proposed refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # reedline `\|/`
+
 A readline replacement written in Rust
 
 ## Example (Simple REPL)
@@ -30,7 +31,8 @@ loop {
 
 ## Are we prompt yet? (Development status)
 
-This crate is currently under active development in Jonathan Turner's [live-coding streams](https://www.twitch.tv/jntrnr). If you want to see a feature, jump by the streams, file an [issue](https://github.com/jonathandturner/reedline/issues) or contribute a [PR](https://github.com/jonathandturner/reedline/pulls)!
+This crate is currently under active development in JT's [live-coding streams](https://www.twitch.tv/jntrnr).
+If you want to see a feature, jump by the streams, file an [issue](https://github.com/jonathandturner/reedline/issues) or contribute a [PR](https://github.com/jonathandturner/reedline/pulls)!
 
 - [x] Basic unicode grapheme aware cursor editing.
 - [x] Configurable prompt
@@ -41,10 +43,10 @@ This crate is currently under active development in Jonathan Turner's [live-codi
 - [ ] Content aware highlighting or validation.
 - [ ] Autocompletion.
 
-For a more detailed roadmap checkout [TODO.txt](https://github.com/jonathandturner/reedline/blob/main/TODO.txt).
+For a more detailed roadmap check out [TODO.txt](https://github.com/jonathandturner/reedline/blob/main/TODO.txt).
 
 ### Alternatives
 
-For currently more mature Rust line editing checkout:
+For currently more mature Rust line editing check out:
 
 - [rustyline](https://crates.io/crates/rustyline)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -295,7 +295,7 @@ impl Reedline {
                 EditCommand::PreviousHistory => {
                     if self.history.history_prefix.is_none() {
                         let buffer = self.line_buffer.get_buffer();
-                        self.history.history_prefix = Some(buffer.clone());
+                        self.history.history_prefix = Some(buffer.to_owned());
                     }
 
                     if let Some(history_entry) = self.history.go_back_with_prefix() {
@@ -307,7 +307,7 @@ impl Reedline {
                 EditCommand::NextHistory => {
                     if self.history.history_prefix.is_none() {
                         let buffer = self.line_buffer.get_buffer();
-                        self.history.history_prefix = Some(buffer.clone());
+                        self.history.history_prefix = Some(buffer.to_owned());
                     }
 
                     if let Some(history_entry) = self.history.go_forward_with_prefix() {
@@ -323,13 +323,12 @@ impl Reedline {
                     let insertion_offset = self.insertion_point().offset;
                     if insertion_offset > 0 {
                         self.cut_buffer
-                            .set(&self.line_buffer.insertion_line()[..insertion_offset]);
+                            .set(&self.line_buffer.get_buffer()[..insertion_offset]);
                         self.clear_to_insertion_point();
                     }
                 }
                 EditCommand::CutToEnd => {
-                    let cut_slice =
-                        &self.line_buffer.insertion_line()[self.insertion_point().offset..];
+                    let cut_slice = &self.line_buffer.get_buffer()[self.insertion_point().offset..];
                     if !cut_slice.is_empty() {
                         self.cut_buffer.set(cut_slice);
                         self.clear_to_end();
@@ -341,7 +340,7 @@ impl Reedline {
                     if left_index < insertion_offset {
                         let cut_range = left_index..insertion_offset;
                         self.cut_buffer
-                            .set(&self.line_buffer.insertion_line()[cut_range.clone()]);
+                            .set(&self.line_buffer.get_buffer()[cut_range.clone()]);
                         self.clear_range(cut_range);
                         self.set_insertion_point(left_index);
                     }
@@ -352,7 +351,7 @@ impl Reedline {
                     if right_index > insertion_offset {
                         let cut_range = insertion_offset..right_index;
                         self.cut_buffer
-                            .set(&self.line_buffer.insertion_line()[cut_range.clone()]);
+                            .set(&self.line_buffer.get_buffer()[cut_range.clone()]);
                         self.clear_range(cut_range);
                     }
                 }
@@ -427,7 +426,7 @@ impl Reedline {
 
                     if insertion_offset == 0 {
                         self.line_buffer.move_right()
-                    } else if insertion_offset == self.line_buffer.insertion_line().len() {
+                    } else if insertion_offset == self.line_buffer.get_buffer().len() {
                         self.line_buffer.move_left()
                     }
                     let grapheme_1_start = self.line_buffer.grapheme_left_index();
@@ -480,7 +479,7 @@ impl Reedline {
 
     /// Get the current line of a multi-line edit [`LineBuffer`]
     fn insertion_line(&self) -> &str {
-        self.line_buffer.insertion_line()
+        self.line_buffer.get_buffer()
     }
 
     /// Reset the [`LineBuffer`] to be a line specified by `buffer`

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,12 +1,7 @@
-use crate::{
-    clip_buffer::{get_default_clipboard, Clipboard},
-    Prompt,
-};
-use crate::{history::History, line_buffer::LineBuffer};
-use crate::{
-    history_search::{BasicSearch, BasicSearchCommand},
-    line_buffer::InsertionPoint,
-};
+use crate::clip_buffer::{get_default_clipboard, Clipboard};
+use crate::history_search::{BasicSearch, BasicSearchCommand};
+use crate::line_buffer::{InsertionPoint, LineBuffer};
+use crate::{EditCommand, History, Prompt, Signal};
 use crossterm::{
     cursor::{position, MoveTo, MoveToColumn, RestorePosition, SavePosition},
     event::{poll, read, Event, KeyCode, KeyEvent, KeyModifiers},
@@ -14,45 +9,11 @@ use crossterm::{
     terminal::{self, Clear, ClearType},
     QueueableCommand, Result,
 };
-use serde::{Deserialize, Serialize};
 
 use std::{
     io::{stdout, Stdout, Write},
     time::Duration,
 };
-
-/// Editing actions which can be mapped to key bindings.
-///
-/// Executed by [`Reedline::run_edit_commands()`]
-#[derive(Clone, Serialize, Deserialize)]
-pub enum EditCommand {
-    MoveToStart,
-    MoveToEnd,
-    MoveLeft,
-    MoveRight,
-    MoveWordLeft,
-    MoveWordRight,
-    InsertChar(char),
-    Backspace,
-    Delete,
-    BackspaceWord,
-    DeleteWord,
-    AppendToHistory,
-    PreviousHistory,
-    NextHistory,
-    SearchHistory,
-    Clear,
-    CutFromStart,
-    CutToEnd,
-    CutWordLeft,
-    CutWordRight,
-    InsertCutBuffer,
-    UppercaseWord,
-    LowercaseWord,
-    CapitalizeChar,
-    SwapWords,
-    SwapGraphemes,
-}
 
 /// Line editor engine
 ///
@@ -84,18 +45,6 @@ pub struct Reedline {
 
     // Stdout
     stdout: Stdout,
-}
-
-/// Valid ways how [`Reedline::read_line()`] can return
-pub enum Signal {
-    /// Entry succeeded with the provided content
-    Success(String),
-    /// Entry was aborted with `Ctrl+C`
-    CtrlC, // Interrupt current editing
-    /// Abort with `Ctrl+D` signalling `EOF` or abort of a whole interactive session
-    CtrlD, // End terminal session
-    /// Signal to clear the current screen. Buffer content remains untouched.
-    CtrlL, // FormFeed/Clear current screen
 }
 
 impl Default for Reedline {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -288,9 +288,6 @@ impl Reedline {
                 }
                 EditCommand::AppendToHistory => {
                     self.history.append(self.insertion_line().to_string());
-                    // reset the history cursor - we want to start at the bottom of the
-                    // history again.
-                    self.history.reset_cursor();
                 }
                 EditCommand::PreviousHistory => {
                     if self.history.history_prefix.is_none() {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,0 +1,46 @@
+use serde::{Deserialize, Serialize};
+
+/// Valid ways how [`Reedline::read_line()`] can return
+pub enum Signal {
+    /// Entry succeeded with the provided content
+    Success(String),
+    /// Entry was aborted with `Ctrl+C`
+    CtrlC, // Interrupt current editing
+    /// Abort with `Ctrl+D` signalling `EOF` or abort of a whole interactive session
+    CtrlD, // End terminal session
+    /// Signal to clear the current screen. Buffer content remains untouched.
+    CtrlL, // FormFeed/Clear current screen
+}
+
+/// Editing actions which can be mapped to key bindings.
+///
+/// Executed by [`Reedline::run_edit_commands()`]
+#[derive(Clone, Serialize, Deserialize)]
+pub enum EditCommand {
+    MoveToStart,
+    MoveToEnd,
+    MoveLeft,
+    MoveRight,
+    MoveWordLeft,
+    MoveWordRight,
+    InsertChar(char),
+    Backspace,
+    Delete,
+    BackspaceWord,
+    DeleteWord,
+    AppendToHistory,
+    PreviousHistory,
+    NextHistory,
+    SearchHistory,
+    Clear,
+    CutFromStart,
+    CutToEnd,
+    CutWordLeft,
+    CutWordRight,
+    InsertCutBuffer,
+    UppercaseWord,
+    LowercaseWord,
+    CapitalizeChar,
+    SwapWords,
+    SwapGraphemes,
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -43,7 +43,7 @@ pub struct History {
     truncate_file: bool, // as long as the file would not exceed capacity we can use appending writes
 
     /// The prefix to search the history in a stateful manner using [`History::go_forward_with_prefix`] and [`History::go_back_with_prefix`]
-    pub history_prefix: Option<String>, 
+    pub history_prefix: Option<String>,
 }
 
 impl Default for History {
@@ -185,7 +185,8 @@ impl History {
         &self.entries
     }
 
-    /// Appends an entry if non-empty and not repetition of the previous entry
+    /// Appends an entry if non-empty and not repetition of the previous entry.
+    /// Resets the browsing cursor to the default state in front of the most recent entry.
     ///
     /// ```
     /// # use reedline::History;
@@ -210,16 +211,12 @@ impl History {
                 // History is "full", so we delete the oldest entry first,
                 // before adding a new one.
                 self.entries.pop_front();
-                self.cursor = self.cursor.saturating_sub(1);
                 self.len_on_disk = self.len_on_disk.saturating_sub(1);
                 self.truncate_file = true;
             }
-            // Keep the cursor meaning consistent if no call to `reset_cursor()` is done by the consumer
-            if self.cursor == self.entries.len() {
-                self.cursor += 1;
-            }
             self.entries.push_back(entry);
         }
+        self.reset_cursor()
     }
 
     /// Reset the internal browsing cursor

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -1,4 +1,4 @@
-use crate::engine::EditCommand;
+use crate::EditCommand;
 use crossterm::event::{KeyCode, KeyModifiers};
 use serde::{Deserialize, Serialize};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,8 +54,12 @@
 //! * [rustyline](https://crates.io/crates/rustyline)
 mod clip_buffer;
 
+mod enums;
+pub(crate) use enums::EditCommand;
+pub use enums::Signal;
+
 mod engine;
-pub use engine::{Reedline, Signal};
+pub use engine::Reedline;
 
 mod history;
 pub use history::{History, HISTORY_SIZE};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,11 +45,11 @@
 //! * `[ ]` Content aware highlighting or validation.
 //! * `[ ]` Autocompletion.
 //!
-//! For a more detailed roadmap checkout [TODO.txt](https://github.com/jonathandturner/reedline/blob/main/TODO.txt).
+//! For a more detailed roadmap check out [TODO.txt](https://github.com/jonathandturner/reedline/blob/main/TODO.txt).
 //!
 //! ### Alternatives
 //!
-//! For currently more mature Rust line editing checkout:
+//! For currently more mature Rust line editing check out:
 //!
 //! * [rustyline](https://crates.io/crates/rustyline)
 mod clip_buffer;
@@ -66,7 +66,6 @@ mod prompt;
 pub use prompt::{DefaultPrompt, Prompt, DEFAULT_PROMPT_COLOR, DEFAULT_PROMPT_INDICATOR};
 
 mod line_buffer;
-pub use line_buffer::LineBuffer;
 
 mod keybindings;
 pub use keybindings::default_keybindings;

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -52,12 +52,8 @@ impl LineBuffer {
         self.insertion_point = pos;
     }
 
-    pub fn get_buffer(&self) -> String {
-        self.lines[self.insertion_point.line].clone()
-    }
-
     /// Output the current line in the multiline buffer
-    pub fn insertion_line(&self) -> &str {
+    pub fn get_buffer(&self) -> &str {
         &self.lines[self.insertion_point.line]
     }
 
@@ -195,7 +191,7 @@ impl LineBuffer {
         self.lines[self.insertion_point.line][self.insertion_point.offset..]
             .chars()
             .next()
-            .map(|c| c.is_whitespace())
+            .map(char::is_whitespace)
             .unwrap_or(false)
     }
 }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -8,7 +8,7 @@ pub static DEFAULT_PROMPT_INDICATOR: &str = "〉";
 /// API to provide a custom prompt.
 ///
 /// Implementors have to provide [`String`]-based content which will be
-/// displayed before the [`LineBuffer`](crate::LineBuffer) is drawn.
+/// displayed before the `LineBuffer` is drawn.
 pub trait Prompt {
     /// Provide content off the full prompt. May use a line above the entry buffer that fits into `screen_width`.
     fn render_prompt(&self, screen_width: usize) -> String;


### PR DESCRIPTION
* Small cleanup stuff
* Tests for the new up/down prefix search

Potentially opinionated:

* Make the reset of the history cursor to now part of the `History.append()` contract
* To slim down `src/engine.rs` extract the `EditCommand` and `Signal` enums into a new module