### PR TITLE
Fix Windows prompt

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -689,6 +689,7 @@ impl Reedline {
         let prompt_origin = position()?;
 
         self.queue_prompt(prompt, terminal_size.0 as usize)?;
+        self.stdout.flush()?;
 
         // set where the input begins
         let mut prompt_offset = position()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() -> Result<()> {
 
     let mut line_editor = Reedline::new()
         .with_history("history.txt", 5)?
-        .with_edit_mode(reedline::EditMode::ViNormal)
+        .with_edit_mode(reedline::EditMode::Emacs)
         .with_keybindings(keybindings);
 
     let prompt = DefaultPrompt::new(DEFAULT_PROMPT_COLOR, DEFAULT_PROMPT_INDICATOR, 1);


### PR DESCRIPTION
Make sure to flush before we check for the prompt position. Fixes the prompt in Windows