### PR TITLE
Add pretty_assertions lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +104,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deser-hjson"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +121,12 @@ checksum = "1b28e438b793f41d0a6401a58ed95ce02f2f36a45af9ef929c7e4a0a6453f0f6"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "getrandom"
@@ -281,6 +306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +344,18 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -388,6 +434,7 @@ dependencies = [
  "deser-hjson",
  "nu-ansi-term",
  "nu-json",
+ "pretty_assertions",
  "serde",
  "tempfile",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ unicode-width = "0.1.8"
 
 [dev-dependencies]
 tempfile = "3.2.0"
+pretty_assertions = "0.7.2"
 
 [features]
 system_clipboard = ["clipboard"]

--- a/src/history.rs
+++ b/src/history.rs
@@ -428,6 +428,7 @@ impl Drop for History {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
     use std::io::BufRead;
 
     use super::History;

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -319,6 +319,7 @@ fn is_word_boundary(s: &str) -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     fn buffer_with(content: &str) -> LineBuffer {
         let mut line_buffer = LineBuffer::new();


### PR DESCRIPTION
This improves the test diff output a lot and consequently makes going through diffs a joy! Attaching a screenshot to showcase the difference this will make.

### Before

![scrot_2021-06-23-162005](https://user-images.githubusercontent.com/10345612/123085337-bf278b00-d43f-11eb-9520-e411f962a5e0.png)

### After

![scrot_2021-06-23-161942](https://user-images.githubusercontent.com/10345612/123085359-c484d580-d43f-11eb-9253-20ea4bea5242.png)

ref: https://github.com/jonathandturner/reedline/pull/71#discussion_r655307424