### PR TITLE
Extending PromptMode

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2,7 +2,7 @@ use crate::{
     clip_buffer::{get_default_clipboard, Clipboard},
     default_emacs_keybindings,
     keybindings::{default_vi_insert_keybindings, default_vi_normal_keybindings, Keybindings},
-    prompt::PromptMode,
+    prompt::{PromptEditMode, PromptViMode},
     DefaultPrompt, Prompt,
 };
 use crate::{history::History, line_buffer::LineBuffer};
@@ -147,10 +147,11 @@ impl Reedline {
         self.edit_mode
     }
 
-    pub fn prompt_mode(&self) -> PromptMode {
+    pub fn prompt_edit_mode(&self) -> PromptEditMode {
         match self.edit_mode {
-            EditMode::ViInsert => PromptMode::ViInsert,
-            _ => PromptMode::Normal,
+            EditMode::ViInsert => PromptEditMode::Vi(PromptViMode::Insert),
+            EditMode::ViNormal => PromptEditMode::Vi(PromptViMode::Normal),
+            EditMode::Emacs => PromptEditMode::Emacs,
         }
     }
 
@@ -636,7 +637,7 @@ impl Reedline {
     /// Used at the beginning of each [`Reedline::read_line()`] call.
     fn queue_prompt(&mut self, screen_width: usize) -> Result<()> {
         // print our prompt
-        let prompt_mode = self.prompt_mode();
+        let prompt_mode = self.prompt_edit_mode();
 
         self.stdout
             .queue(MoveToColumn(0))?
@@ -654,7 +655,7 @@ impl Reedline {
     /// the prompt
     fn queue_prompt_indicator(&mut self) -> Result<()> {
         // print our prompt
-        let prompt_mode = self.prompt_mode();
+        let prompt_mode = self.prompt_edit_mode();
         self.stdout
             .queue(MoveToColumn(0))?
             .queue(SetForegroundColor(self.prompt.get_prompt_color()))?

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -18,6 +18,15 @@ pub struct PromptHistorySearch {
     term: String,
 }
 
+impl PromptHistorySearch {
+    pub fn new(status: PromptHistorySearchStatus, search_term: String) -> Self {
+        PromptHistorySearch {
+            status,
+            term: search_term,
+        }
+    }
+}
+
 pub enum PromptEditMode {
     Default,
     Emacs,


### PR DESCRIPTION
The idea here is that what we want to display on the screen which can impact the prompt should be available as part of the prompt's interface.

So here are the things that can impact what we show with our prompt
- The line-editor can either be in Emacs mode or VI modes (for now) [These are exclusive to one another]
- The line-editor can be either in editing a command or searching history mode [These two states are also exclusive]
- Lastly, the command can be either single-line or multi-line.

Now all these variables can happen together (i.e. they form a cross-product)
- example 1: You can be in vi-normal mode and be editing history search term and that particular term earlier resulted in a multi-line command. (So, we need to showcase all these three variations together)

one way to do this is using a struct, something like the following.

```rust
pub struct PromptMode {
  command_edit_mode: InputMode,
  edit_mode: PromptEditMode,
  line_mode: PromptLineMode,
}
```

I found that it was making the more frequent case (of being in edit mode) overly complex so I chose to expose the functionality using separate methods.

## Usecases
I considered the following use-cases. Hopefully, these cover all the broad pieces that can impact the desing choices.

### A single line command
```
reedline on  rework-prompt-responsibilities [$?] is 📦 v0.1.0 via 🦀 v1.52.1 took 4s 
Insert ❯ ls|
^---- This is where `render_prompt` ends and `render_indicator` starts
```
1. `render_prompt`
2. `render_indicator`
3. first line of the line_buffer

### Insert a multiline command
```
reedline on  rework-prompt-responsibilities [$?] is 📦 v0.1.0 via 🦀 v1.52.1 took 4s 
Normal ❯ curl -XPOST http://localhost:5000/dummy -d'{
:::   x: 90█                                          <- Vi Normal Mode indicator (on a comma)
:::   y: 90,
::: }'
^---- here we call the multiline indicator basically boils down to be:
---- `zip (tail line_buffer) (repeat render_multiline_prompt_indicator)`
```
1.  `render_prompt`
2. `render_indicator`
3. render first line of the line_buffer
4. Something like `zipWith (\line indicator -> indicator ++ "  " ++ line) (tail input_buffer) (repeat render_multi_line_buffer)`
NOTE: The multiline render and the `render_indicator` as used together here.

### History Search: separate line
```
reedline on  rework-prompt-responsibilities [$?] is 📦 v0.1.0 via 🦀 v1.52.1 took 4s 
Insert ❯ ls                                     <- displaying what command will be filled in
(history-search: "ls|")                         <- history display using `render_history_indicator`
```

### History Search: separate line + multiline command
```
reedline on  rework-prompt-responsibilities [$?] is 📦 v0.1.0 via 🦀 v1.52.1 took 4s 
Normal ❯ curl -XPOST http://localhost:5000/dummy -d'{  <- displaying what command will be filled in along with mode
:::   x: 90,                                           <- multiline prompt indicator
:::   y: 90,
::: }'
(history-search: "XPOST loa█lhost")                    <- history display using `render_history_indicator`
```
1.  `render_prompt`
2. `render_indicator`
3. Render first line of the line_buffer
4. Something like `zipWith (\line indicator -> indicator ++ "  " ++ line) (tail input_buffer) (repeat render_multi_line_buffer)`
5. `render_history_search_indicator`

### Others
We can imagine how
- history on the same line with the command
- these with emacs mode, or vi-visual mode
- etc.
would also be easily representable if we can solve for the above ones.

Again this PR is pretty much in the draft state right now and if this is something that you'd like to include in the codebase let me know and I will add a few tests, and replace the multiline indicator usage etc.


