### PR TITLE
fix: overwriting of line #76

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -768,14 +768,18 @@ impl Reedline {
 
         let mut terminal_size = terminal::size()?;
 
-        self.stdout.queue(Print("\r\n"))?.flush()?;
-
         let mut prompt_origin = {
             let (column, row) = position()?;
-            if row + 1 == terminal_size.1 {
-                (column, row.saturating_sub(1))
+            if (column, row) == (0, 0) {
+                (0, 0)
+            } else if row + 1 == terminal_size.1 {
+                self.stdout.queue(Print("\r\n\r\n"))?.flush()?;
+                (0, row.saturating_sub(1))
+            } else if row + 2 == terminal_size.1 {
+                self.stdout.queue(Print("\r\n\r\n"))?.flush()?;
+                (0, row)
             } else {
-                (column, row)
+                (0, row + 1)
             }
         };
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -768,6 +768,8 @@ impl Reedline {
 
         let mut terminal_size = terminal::size()?;
 
+        self.stdout.queue(Print("\r\n"))?.flush()?;
+
         let mut prompt_origin = {
             let (column, row) = position()?;
             if row + 1 == terminal_size.1 {


### PR DESCRIPTION
This happened, because the `prompt` would be drawn at the `origin`, which was determined to be at the `position()?`, which was in the previous line. 
Now, move one line downwards before determining the `origin`.