### PR TITLE
Extract screen painting stuff into a separate struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@ mod clip_buffer;
 mod enums;
 pub use enums::{EditCommand, EditMode, Signal};
 
+mod painter;
+
 mod engine;
 pub use engine::Reedline;
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -1,0 +1,199 @@
+use crate::{
+    prompt::{PromptEditMode, PromptHistorySearch},
+    Prompt,
+};
+use crossterm::{
+    cursor::{self, position, MoveTo, MoveToColumn, RestorePosition, SavePosition},
+    style::{Color, Print, ResetColor, SetForegroundColor},
+    terminal::{self, Clear, ClearType},
+    QueueableCommand, Result,
+};
+
+use std::io::{Stdout, Write};
+
+pub struct Painter {
+    // Stdout
+    stdout: Stdout,
+}
+
+impl Painter {
+    pub fn new(stdout: Stdout) -> Self {
+        Painter { stdout }
+    }
+
+    pub fn queue_move_to(&mut self, column: u16, row: u16) -> Result<()> {
+        self.stdout.queue(cursor::MoveTo(column, row))?;
+
+        Ok(())
+    }
+
+    /// Queue the complete prompt to display including status indicators (e.g. pwd, time)
+    ///
+    /// Used at the beginning of each [`Reedline::read_line()`] call.
+    pub fn queue_prompt(
+        &mut self,
+        prompt: &dyn Prompt,
+        prompt_mode: PromptEditMode,
+        terminal_size: (u16, u16),
+    ) -> Result<()> {
+        let (screen_width, _) = terminal_size;
+
+        // print our prompt
+        self.stdout
+            .queue(MoveToColumn(0))?
+            .queue(SetForegroundColor(prompt.get_prompt_color()))?
+            .queue(Print(prompt.render_prompt(screen_width as usize)))?
+            .queue(Print(prompt.render_prompt_indicator(prompt_mode)))?
+            .queue(ResetColor)?;
+
+        Ok(())
+    }
+
+    /// Queue prompt components preceding the buffer to display
+    ///
+    /// Used to restore the prompt indicator after a search etc. that affected
+    /// the prompt
+    pub fn queue_prompt_indicator(
+        &mut self,
+        prompt: &dyn Prompt,
+        prompt_mode: PromptEditMode,
+    ) -> Result<()> {
+        // print our prompt
+        self.stdout
+            .queue(MoveToColumn(0))?
+            .queue(SetForegroundColor(prompt.get_prompt_color()))?
+            .queue(Print(prompt.render_prompt_indicator(prompt_mode)))?
+            .queue(ResetColor)?;
+
+        Ok(())
+    }
+
+    /// Repaint logic for the normal input prompt buffer
+    ///
+    /// Requires coordinates where the input buffer begins after the prompt.
+    pub fn queue_buffer(
+        &mut self,
+        buffer: String,
+        offset: (u16, u16),
+        cursor_index_in_buffer: usize,
+    ) -> Result<()> {
+        // Repaint logic:
+        //
+        // Start after the prompt
+        // Draw the string slice from 0 to the grapheme start left of insertion point
+        // Then, get the position on the screen
+        // Then draw the remainer of the buffer from above
+        // Finally, reset the cursor to the saved position
+
+        self.stdout
+            .queue(MoveTo(offset.0, offset.1))?
+            .queue(Print(&buffer[0..cursor_index_in_buffer]))?
+            .queue(SavePosition)?
+            .queue(Print(&buffer[cursor_index_in_buffer..]))?
+            .queue(Clear(ClearType::FromCursorDown))?
+            .queue(RestorePosition)?;
+
+        Ok(())
+    }
+
+    pub fn repaint_everything(
+        &mut self,
+        prompt: &dyn Prompt,
+        prompt_mode: PromptEditMode,
+        prompt_origin: (u16, u16),
+        cursor_position_in_buffer: usize,
+        buffer: String,
+        terminal_size: (u16, u16),
+    ) -> Result<(u16, u16)> {
+        self.stdout.queue(cursor::Hide)?;
+        self.queue_move_to(prompt_origin.0, prompt_origin.1)?;
+        self.queue_prompt(prompt, prompt_mode, terminal_size)?;
+        self.stdout.queue(cursor::Show)?;
+        self.flush()?;
+        // set where the input begins
+        let prompt_offset = position()?;
+        self.queue_buffer(buffer, prompt_offset, cursor_position_in_buffer)?;
+        self.stdout.queue(cursor::Show)?;
+        self.flush()?;
+
+        Ok(prompt_offset)
+    }
+
+    pub fn queue_history_search_indicator(
+        &mut self,
+        prompt: &dyn Prompt,
+        prompt_search: PromptHistorySearch,
+    ) -> Result<()> {
+        // print search prompt
+        self.stdout
+            .queue(MoveToColumn(0))?
+            .queue(SetForegroundColor(Color::Blue))?
+            .queue(Print(
+                prompt.render_prompt_history_search_indicator(prompt_search),
+            ))?
+            .queue(ResetColor)?;
+
+        Ok(())
+    }
+
+    pub fn queue_history_results(&mut self, history_result: &String, offset: usize) -> Result<()> {
+        self.stdout
+            .queue(Print(&history_result[..offset]))?
+            .queue(SavePosition)?
+            .queue(Print(&history_result[offset..]))?
+            .queue(Clear(ClearType::UntilNewLine))?
+            .queue(RestorePosition)?;
+
+        Ok(())
+    }
+
+    /// Writes `line` to the terminal with a following carriage return and newline
+    pub fn paint_line(&mut self, line: &str) -> Result<()> {
+        self.stdout
+            .queue(Print(line))?
+            .queue(Print("\n"))?
+            .queue(MoveToColumn(1))?;
+        self.stdout.flush()?;
+
+        Ok(())
+    }
+
+    /// Goes to the beginning of the next line
+    ///
+    /// Also works in raw mode
+    pub fn paint_crlf(&mut self) -> Result<()> {
+        self.stdout.queue(Print("\n"))?.queue(MoveToColumn(1))?;
+        self.stdout.flush()?;
+
+        Ok(())
+    }
+
+    // Printing carrige return
+    pub fn paint_carrige_return(&mut self) -> Result<()> {
+        self.stdout.queue(Print("\r\n\r\n"))?.flush()
+    }
+
+    /// Clear the screen by printing enough whitespace to start the prompt or
+    /// other output back at the first line of the terminal.
+    pub fn clear_screen(&mut self) -> Result<()> {
+        let (_, num_lines) = terminal::size()?;
+        for _ in 0..2 * num_lines {
+            self.stdout.queue(Print("\n"))?;
+        }
+        self.stdout.queue(MoveTo(0, 0))?;
+        self.stdout.flush()?;
+
+        Ok(())
+    }
+
+    pub fn clear_until_newline(&mut self) -> Result<()> {
+        self.stdout.queue(Clear(ClearType::UntilNewLine))?;
+        self.stdout.flush()?;
+
+        Ok(())
+    }
+
+    pub fn flush(&mut self) -> Result<()> {
+        self.stdout.flush()
+    }
+}


### PR DESCRIPTION
From https://github.com/jonathandturner/reedline/pull/62 > https://github.com/jonathandturner/reedline/pull/62#issuecomment-864614387

> Extracting the Painter seems to absolute clean up some clutter and makes changes to output code centralized. Full endorsement from my side.
Future thought: Maybe the Painter could also do the bookkeeping on the terminal positions regarding where the current prompt started/where the current offsets are (in this case maybe named TerminalOutput) (need to be called on resize)
With a good design it is probably reasonable to hand out exclusive references of the Painter to (plugin) components.

